### PR TITLE
TTL, Retries and Solo parameters as variables.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,4 +34,8 @@ cloudflare_email: ""
 cloudflare_api_key: ""
 cloudflare_domain: ""
 
+dns_record_ttl: "120"
+acme_certificate_retries: "12"
+solo: true
+
 cleanup_all: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,9 +43,9 @@
 
 - name: generate the CSR
   command: |
-    openssl req -new -sha256 -subj "/CN={{ certificate_common_name }}" 
-    -config "{{ certificate_directory }}/openssl-request.conf"  
-    -key "{{ certificate_directory + '/' + key_filename }}" 
+    openssl req -new -sha256 -subj "/CN={{ certificate_common_name }}"
+    -config "{{ certificate_directory }}/openssl-request.conf"
+    -key "{{ certificate_directory + '/' + key_filename }}"
     -out "{{ certificate_directory + '/' + csr_filename }}"
   args:
     creates: "{{ certificate_directory + '/' + csr_filename }}"
@@ -93,14 +93,15 @@
   tags:
     - web-api
 
-- name: Create DNS Record  
+- name: Create DNS Record
   cloudflare_dns:
     domain: "{{ cloudflare_domain }}"
     record: "_acme-challenge.{{ item.key }}"
     type: TXT
+    ttl: "{{ dns_record_ttl }}"
     value: "\"{{ item.value['dns-01']['resource_value'] }}\""
     state: present
-    solo: true
+    solo: "{{ solo }}"
     account_email: "{{ cloudflare_email }}"
     account_api_token: "{{ cloudflare_api_key }}"
   with_dict: "{{ letsencrypt_challenge['challenge_data'] | default({}) }}"
@@ -118,14 +119,14 @@
     account_email: "{{ letsencrypt_email }}"
     data: "{{ letsencrypt_challenge }}"
   register: letsencrypt_validation
-  retries: 3
+  retries: "{{ acme_certificate_retries }}"
   delay: 10
   until: letsencrypt_validation is success
   when: letsencrypt_challenge['challenge_data'] is defined
   tags:
     - web-api
 
-- name: Delete DNS Record  
+- name: Delete DNS Record
   cloudflare_dns:
     domain: "{{ cloudflare_domain }}"
     record: "_acme-challenge.{{ item.key }}"


### PR DESCRIPTION
Hello Ben

I touched some problems with your role and CF when I tried same domain (checks, tests, so on) many times. As there is no possibility to add TTL now (and retries is equal only 3) many times TXT record was resolved within old one data opposite to new one which already was deployed to CF (within new ansible playbook run) I decided to propose such change to your code. Additionally sometime CF needs more time also then 30 secs to add your DNS entry and then Retries parameter as variable is the only one what we can do :) 

Solo parameter is needed if we want to use molecule for more then one Platform at once :/

If you decided to merge this PR will be super.
Best
-- 
Andrzej