### PR TITLE
Default to using ACME v2 protocol

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,8 @@ letsencrypt_key_size: 2048
 letsencrypt_key_directory: /etc/ssl/lets_encrypt
 letsencrypt_key_filename: letsencrypt_account.key
 letsencrypt_production: no
-letsencrypt_acme_directory: "{{ 'https://acme-v01.api.letsencrypt.org/directory' if letsencrypt_production else 'https://acme-staging.api.letsencrypt.org/directory' }}"
+letsencrypt_acme_directory: "{{ 'https://acme-v02.api.letsencrypt.org/directory' if letsencrypt_production else 'https://acme-staging-v02.api.letsencrypt.org/directory' }}"
+letsencrypt_acme_version: 2
 
 
 include_intermediate: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,12 +83,14 @@
 - name: initiate the Let's Encrypt challenge
   acme_certificate:
     acme_directory: "{{ letsencrypt_acme_directory }}"
+    acme_version: "{{ letsencrypt_acme_version }}"
     challenge: dns-01
     account_key: "{{ letsencrypt_key_directory + '/' + letsencrypt_key_filename }}"
     csr: "{{ certificate_directory + '/' + csr_filename }}"
     dest: "{{ certificate_directory + '/' + crt_filename }}"
     account_email: "{{ letsencrypt_email }}"
     remaining_days: "{{ certificate_remaining_days }}"
+    terms_agreed: yes
   register: letsencrypt_challenge
   tags:
     - web-api
@@ -111,12 +113,14 @@
 - name: validate the Let's Encrypt challenge
   acme_certificate:
     acme_directory: "{{ letsencrypt_acme_directory }}"
+    acme_version: "{{ letsencrypt_acme_version }}"
     challenge: dns-01
     account_key: "{{ letsencrypt_key_directory + '/' + letsencrypt_key_filename }}"
     csr: "{{ certificate_directory + '/' + csr_filename }}"
     dest: "{{ certificate_directory + '/' + crt_filename }}"
     account_email: "{{ letsencrypt_email }}"
     data: "{{ letsencrypt_challenge }}"
+    terms_agreed: yes
   register: letsencrypt_validation
   retries: 3
   delay: 10


### PR DESCRIPTION
ACME v1 protocol has recently been deprecated which means that this role no longer
works out of the box.

Switch over to using ACME v2 protocol by default including adding the now mandatory
terms_agreed parameter so that the role works once again.