### PR TITLE
Fix wildcard certs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,7 +98,7 @@
 - name: Create DNS Record  
   cloudflare_dns:
     domain: "{{ cloudflare_domain }}"
-    record: "_acme-challenge.{{ item.key }}"
+    record: "{{ item.value['dns-01']['record'] }}"
     type: TXT
     value: "\"{{ item.value['dns-01']['resource_value'] }}\""
     state: present
@@ -132,7 +132,7 @@
 - name: Delete DNS Record  
   cloudflare_dns:
     domain: "{{ cloudflare_domain }}"
-    record: "_acme-challenge.{{ item.key }}"
+    record: "{{ item.value['dns-01']['record'] }}"
     type: TXT
     value: "\"{{ item.value['dns-01']['resource_value'] }}\""
     state: absent


### PR DESCRIPTION
It would fail on "validate the Let's Encrypt challenge" when attempting to issue a wildcard cert (which letsencrypt only supports via the DNS challenge method).

It created a record at:
  `_acme-challenge.*.example.com`
rather than what letsencrypt wanted:
  `_acme-challenge.example.com`

This just uses the record name returned by `['challenge_data']` rather than assuming.