### PR TITLE
Use latest intermediate cert

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -145,7 +145,7 @@
 
 - name: download the Let's Encrypt intermediate CA
   get_url:
-    url: https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem
+    url: https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem
     dest: "{{ certificate_directory + '/' + intermediate_filename }}"
     owner: "{{ certificate_files_owner }}"
     group: "{{ certificate_files_group }}"


### PR DESCRIPTION
The intermediate certificate is no longer issued from the X3 authority. The current active authority is R3. 
Sources: 
https://letsencrypt.org/certificates/
https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html